### PR TITLE
Inject testnet port into the environment in the ganache test only

### DIFF
--- a/src/tasks/start/backend/start-ganache.ts
+++ b/src/tasks/start/backend/start-ganache.ts
@@ -31,7 +31,7 @@ export async function startGanache(
   }
 
   const nodeUrl = (bre.network.config as HttpNetworkConfig).url
-  const port = nodeUrl ? parseInt(new URL(nodeUrl).port) : testnetPort
+  const port = nodeUrl ? parsePort(nodeUrl) || testnetPort : testnetPort
 
   // If port is in use, assume that a local chain is already running.
   const portInUse = await tcpPortUsed.check(port)
@@ -64,4 +64,10 @@ export function stopGanache(): void {
   }
 
   server.close()
+}
+
+function parsePort(urlString: string): number | null {
+  const url = new URL(urlString)
+  if (!url || !url.port) return null
+  return parseInt(url.port)
 }

--- a/test/projects/counter/buidler.config.ts
+++ b/test/projects/counter/buidler.config.ts
@@ -13,14 +13,14 @@ const config: BuidlerAragonConfig = {
   defaultNetwork: 'localhost',
   networks: {
     localhost: {
-      url: 'http://localhost:48545', // Intentionally not using default port number (8545).
+      url: 'http://localhost:8545',
       accounts: [
         '0xa8a54b2d8197bc0b19bb8a084031be71835580a01e70a45a13babd16c9bc1563',
         '0xce8e3bda3b44269c147747a373646393b1504bfcbb73fc9564f5d753d8116608'
       ]
     },
     someothernetwork: {
-      url: 'http://localhost:48546'
+      url: 'http://localhost:8546'
     }
   },
   solc: {

--- a/test/projects/test-app/buidler.config.js
+++ b/test/projects/test-app/buidler.config.js
@@ -12,7 +12,7 @@ module.exports = {
   defaultNetwork: 'localhost',
   networks: {
     localhost: {
-      url: 'http://localhost:48545', // Intentionally not using default port number (8545).
+      url: 'http://localhost:8545',
       accounts: [
         '0xa8a54b2d8197bc0b19bb8a084031be71835580a01e70a45a13babd16c9bc1563',
         '0xce8e3bda3b44269c147747a373646393b1504bfcbb73fc9564f5d753d8116608'

--- a/test/projects/token-wrapper/buidler.config.js
+++ b/test/projects/token-wrapper/buidler.config.js
@@ -13,7 +13,7 @@ module.exports = {
   defaultNetwork: 'localhost',
   networks: {
     localhost: {
-      url: 'http://localhost:48545', // Intentionally not using default port number (8545).
+      url: 'http://localhost:8545',
       accounts: [
         '0xa8a54b2d8197bc0b19bb8a084031be71835580a01e70a45a13babd16c9bc1563',
         '0xce8e3bda3b44269c147747a373646393b1504bfcbb73fc9564f5d753d8116608'

--- a/test/src/tasks/start/backend/start-ganache.test.ts
+++ b/test/src/tasks/start/backend/start-ganache.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai'
 import http from 'http'
+import { testnetPort } from '~/src/params'
 import tcpPortUsed from 'tcp-port-used'
-import { testnetPort } from '~/test/test-helpers/params'
 import {
   useDefaultEnvironment,
   useEnvironment
@@ -10,6 +10,7 @@ import {
   startGanache,
   stopGanache
 } from '~/src/tasks/start/backend/start-ganache'
+import { HttpNetworkConfig } from '@nomiclabs/buidler/types'
 
 describe('start-ganache.ts', async function() {
   describe('when using the buidlerevm network', async function() {
@@ -98,6 +99,42 @@ describe('start-ganache.ts', async function() {
           const portInUse = await tcpPortUsed.check(testnetPort)
           assert(!portInUse, 'Target port is still in use')
         })
+      })
+    })
+  })
+
+  describe('Starts ganache in a non-default port by parsing the network url', function() {
+    useEnvironment('counter', 'localhost')
+
+    let networkId: number
+
+    const testnetPortNotDefault = 48545
+
+    before('start ganache', async function() {
+      // Inject a different port into the environment to test support for non-default ports
+      const currentNetwork = this.env.network.config as HttpNetworkConfig
+      currentNetwork.url = `http://localhost:${testnetPortNotDefault}`
+      const res = await startGanache(this.env)
+      networkId = res.networkId
+    })
+
+    it('returns a non-zero network id', async function() {
+      assert.isAbove(networkId, 0, 'Ganache returned an invalid network id')
+    })
+
+    it('uses the target port', async function() {
+      const portInUse = await tcpPortUsed.check(testnetPortNotDefault)
+      assert(portInUse, 'Target port is not in use')
+    })
+
+    describe('when ganache is stopped', async function() {
+      before('stop ganache', function() {
+        stopGanache()
+      })
+
+      it('releases the target port', async function() {
+        const portInUse = await tcpPortUsed.check(testnetPortNotDefault)
+        assert(!portInUse, 'Target port is still in use')
       })
     })
   })

--- a/test/test-helpers/params.ts
+++ b/test/test-helpers/params.ts
@@ -1,1 +1,0 @@
-export const testnetPort = 48545


### PR DESCRIPTION
Tests https://github.com/aragon/buidler-aragon/pull/82 functionality only in the ganache start test. Injects a custom URL with a different port to prevent having to modify the test project's port.